### PR TITLE
Fix type signature of read_problems function

### DIFF
--- a/human_eval/data.py
+++ b/human_eval/data.py
@@ -8,7 +8,7 @@ ROOT = os.path.dirname(os.path.abspath(__file__))
 HUMAN_EVAL = os.path.join(ROOT, "..", "data", "HumanEval.jsonl.gz")
 
 
-def read_problems(evalset_file: str = HUMAN_EVAL) -> Iterable[Dict[str, Dict]]:
+def read_problems(evalset_file: str = HUMAN_EVAL) -> Dict[str, Dict]:
     return {task["task_id"]: task for task in stream_jsonl(evalset_file)}
 
 


### PR DESCRIPTION
The `read_problems` function in `human_eval.data` is actually returning a dictionary, but it is wrongly declared to return a iterable of dictionaries:
```python
def read_problems(evalset_file: str = HUMAN_EVAL) -> Iterable[Dict[str, Dict]]:
```

This is a simple fix of the typo.