### PR TITLE
fix: reset `os.getcwd` system call after sandbox execution

### DIFF
--- a/human_eval/execution.py
+++ b/human_eval/execution.py
@@ -32,7 +32,6 @@ def check_correctness(problem: Dict, completion: str, timeout: float,
             chdir = os.chdir
             getcwd = os.getcwd
 
-
             # Disable functionalities that can make destructive changes to the test.
             reliability_guard()
 
@@ -69,7 +68,6 @@ def check_correctness(problem: Dict, completion: str, timeout: float,
             os.rmdir = rmdir
             os.chdir = chdir
             os.getcwd = getcwd
-
 
     manager = multiprocessing.Manager()
     result = manager.list()

--- a/human_eval/execution.py
+++ b/human_eval/execution.py
@@ -30,6 +30,8 @@ def check_correctness(problem: Dict, completion: str, timeout: float,
             rmtree = shutil.rmtree
             rmdir = os.rmdir
             chdir = os.chdir
+            getcwd = os.getcwd
+
 
             # Disable functionalities that can make destructive changes to the test.
             reliability_guard()
@@ -66,6 +68,8 @@ def check_correctness(problem: Dict, completion: str, timeout: float,
             shutil.rmtree = rmtree
             os.rmdir = rmdir
             os.chdir = chdir
+            os.getcwd = getcwd
+
 
     manager = multiprocessing.Manager()
     result = manager.list()


### PR DESCRIPTION
- Reset `os.getcwd()` after sandbox execution, since it is invoked by `create_tempdir()`