### PR TITLE
Fix estimate_pass_at_k returning 1.0 when there are no correct samples (#35)

### DIFF
--- a/human_eval/evaluation.py
+++ b/human_eval/evaluation.py
@@ -23,6 +23,11 @@ def estimate_pass_at_k(
         """
         Calculates 1 - comb(n - c, k) / comb(n, k).
         """
+        if c == 0:
+            # With no correct samples, pass@k is exactly 0 for any k. Guarding
+            # this here avoids the ``n - c < k`` shortcut below wrongly returning
+            # 1.0 when ``k`` exceeds the number of samples ``n``.
+            return 0.0
         if n - c < k:
             return 1.0
         return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))

--- a/human_eval/test_evaluation.py
+++ b/human_eval/test_evaluation.py
@@ -1,0 +1,42 @@
+import unittest
+
+from human_eval.evaluation import estimate_pass_at_k
+
+
+class EstimatePassAtKTest(unittest.TestCase):
+    def test_zero_correct_with_k_greater_than_n(self):
+        # Regression test for https://github.com/openai/human-eval/issues/35
+        # With no correct samples, pass@k is exactly 0 for any k. Previously the
+        # ``n - c < k`` shortcut returned 1.0 when k exceeded the sample count.
+        self.assertEqual(estimate_pass_at_k([2], [0], 5).tolist(), [0.0])
+
+    def test_zero_correct_with_k_leq_n(self):
+        # No correct samples must yield 0 regardless of k <= n.
+        self.assertEqual(estimate_pass_at_k([10], [0], 1).tolist(), [0.0])
+        self.assertEqual(estimate_pass_at_k([10], [0], 10).tolist(), [0.0])
+
+    def test_all_correct(self):
+        # Every sample correct must yield pass@k == 1.
+        self.assertEqual(estimate_pass_at_k([5], [5], 1).tolist(), [1.0])
+        self.assertEqual(estimate_pass_at_k([5], [5], 5).tolist(), [1.0])
+
+    def test_fewer_incorrect_than_k_is_guaranteed_pass(self):
+        # With at least one correct sample and n - c < k, a correct sample is
+        # always drawn, so pass@k == 1.
+        self.assertEqual(estimate_pass_at_k([2], [1], 5).tolist(), [1.0])
+
+    def test_known_value(self):
+        # 3 correct out of 6 -> pass@1 == 1 - C(3,1)/C(6,1) == 0.5.
+        result = estimate_pass_at_k([6], [3], 1)
+        self.assertAlmostEqual(result[0], 0.5)
+
+    def test_scalar_num_samples(self):
+        # num_samples may be a single int shared across all problems.
+        result = estimate_pass_at_k(6, [0, 3, 6], 1).tolist()
+        self.assertEqual(result[0], 0.0)
+        self.assertAlmostEqual(result[1], 0.5)
+        self.assertEqual(result[2], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`estimate_pass_at_k` returns `1.0` for a problem that has **no correct samples** when `k` exceeds the number of samples. That is wrong: with zero correct samples, pass@k is exactly `0` for any `k`.

The estimator uses a shortcut:

```python
def estimator(n: int, c: int, k: int) -> float:
    if n - c < k:
        return 1.0
    return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))
```

The `n - c < k` branch encodes "there are too few incorrect samples to avoid drawing a correct one, so a correct sample is guaranteed." That reasoning only holds when at least one correct sample exists (`c > 0`). When `c == 0` and `k > n` (so `n - c = n < k`), the branch is taken and returns `1.0`, even though there is nothing correct to draw.

This was reported in #35.

```python
>>> from human_eval.evaluation import estimate_pass_at_k
>>> estimate_pass_at_k([2], [0], 5)   # 0 correct out of 2, k=5
array([1.])                            # expected: array([0.])
```

`evaluate_functional_correctness` guards its own calls with `(total >= k).all()` (so `n >= k`), which is why the main pipeline never hits this branch. But `estimate_pass_at_k` is a public, widely-imported helper, and downstream callers that compute pass@k with `k > n` get an incorrect `1.0` for unsolved problems.

## Fix

Return `0.0` up front whenever `c == 0`:

```python
if c == 0:
    return 0.0
if n - c < k:
    return 1.0
return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))
```

For `c == 0` with `k <= n` the estimator formula already evaluated to `0.0` (the `np.arange(n + 1, n + 1)` product is empty → `1.0`, giving `1 - 1 = 0`), so behavior is unchanged there and for every `c > 0` case. Only the previously incorrect `c == 0, k > n` branch changes.

## Verification

- Added `human_eval/test_evaluation.py` (stdlib `unittest`, no new dependencies) covering the regression plus the all-correct, guaranteed-pass, known-value (`pass@1 == 0.5` for 3/6), and scalar-`num_samples` cases. All pass:

  ```
  $ python -m unittest human_eval.test_evaluation
  ......
  Ran 6 tests in 0.000s
  OK
  ```

- Before the fix `estimate_pass_at_k([2], [0], 5)` returned `[1.0]`; after, it returns `[0.0]`.
- The README sanity check is unchanged: `evaluate_functional_correctness` on the bundled example samples still yields `pass@1: 0.4999999999999999`.

Fixes #35